### PR TITLE
Change PRINT with PRINT_DATA

### DIFF
--- a/arch/common/semihost.c
+++ b/arch/common/semihost.c
@@ -129,3 +129,9 @@ long semihost_write(long fd, const void *buf, long len)
 
 	return semihost_exec(SEMIHOST_WRITE, &args);
 }
+
+void semihost_exit(void)
+{
+	semihost_exec(SEMIHOST_EXIT, 0);
+	// return semihost_exec(SEMIHOST_EXIT, 0);
+}

--- a/include/zephyr/arch/common/semihost.h
+++ b/include/zephyr/arch/common/semihost.h
@@ -19,6 +19,10 @@
  * @{
  */
 
+#ifdef __cplusplus
+extern "C" {
+	#endif
+
 #ifndef ZEPHYR_INCLUDE_ARCH_COMMON_SEMIHOST_H_
 #define ZEPHYR_INCLUDE_ARCH_COMMON_SEMIHOST_H_
 
@@ -48,6 +52,8 @@ enum semihost_instr {
 	SEMIHOST_REMOVE = 0x0E,
 	/** Rename a file on the host system. Possibly insecure! */
 	SEMIHOST_RENAME = 0x0F,
+	/** Exit semihosting */
+	SEMIHOST_EXIT = 0x18,
 
 	/*
 	 * Terminal I/O operations
@@ -193,8 +199,14 @@ long semihost_read(long fd, void *buf, long len);
  */
 long semihost_write(long fd, const void *buf, long len);
 
+void semihost_exit(void);
+
 /**
  * @}
  */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_COMMON_SEMIHOST_H_ */
+
+#ifdef __cplusplus
+}
+#endif

--- a/subsys/testsuite/ztest/include/zephyr/ztest.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest.h
@@ -41,15 +41,19 @@ typedef struct esf z_arch_esf_t;
 #endif
 #endif /* KERNEL */
 
-#include <zephyr/sys/printk.h>
-#define PRINT printk
+
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/tc_util.h>
+#ifndef PRINT
+#include <zephyr/sys/printk.h>
+#define PRINT printk
+#endif
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_mock.h>
 #include <zephyr/ztest_test.h>
-#include <zephyr/tc_util.h>
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -30,6 +30,8 @@ static bool failed_expectation;
 #define NUM_ITER_PER_TEST  1
 #endif
 
+#include <zephyr/arch/common/semihost.h>
+
 /* ZTEST_DMEM and ZTEST_BMEM are used for the application shared memory test  */
 
 /**
@@ -1101,6 +1103,7 @@ int main(void)
 			state.boots = 0;
 		}
 	}
+    semihost_exit();
 	return 0;
 }
 #endif


### PR DESCRIPTION
To help with getting the ztest asserts and others to print using semihost_log. This alone is not enough
for semihost_log to print ztest asserts. You have to make sure that you have the `tc_util_user_override.h` file created with similar contents:
```
#ifndef __TC_UTIL_USER_OVERRIDE_H__
#define __TC_UTIL_USER_OVERRIDE_H__

#include "semihost_extra.h"

// custom PRINT_DATA (replacing serial output with semihost writes)
#define PRINT_DATA(fmt, ...) semihost_log(fmt, ##__VA_ARGS__)
#define PRINT PRINT_DATA

#endif /* __TC_UTIL_USER_OVERRIDE_H__ */
```

Also make sure to add these configuration options to your test project:
```
CONFIG_ZTEST_VERBOSE_OUTPUT=y
CONFIG_ZTEST_ASSERT_VERBOSE=2
CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE=y
```
You can set CONFIG_ZTEST_ASSERT_VERBOSE to 1 to see failure data, 0 to only see failure line, 2 to see even successful lines of asserts.

Sorry about duplicating the last commit, I mixed up some branching.