### PR TITLE
Fix ability to override PRINT and PRINT_DATA

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest.h
@@ -41,15 +41,19 @@ typedef struct esf z_arch_esf_t;
 #endif
 #endif /* KERNEL */
 
-#include <zephyr/sys/printk.h>
-#define PRINT printk
+
 
 #include <zephyr/kernel.h>
 
+#include <zephyr/tc_util.h>
+#ifndef PRINT
+#include <zephyr/sys/printk.h>
+#define PRINT printk
+#endif
 #include <zephyr/ztest_assert.h>
 #include <zephyr/ztest_mock.h>
 #include <zephyr/ztest_test.h>
-#include <zephyr/tc_util.h>
+
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
To help with getting the ztest asserts and others to print using semihost_log. This alone is not enough
for semihost_log to print ztest asserts. You have to make sure that you have the `tc_util_user_override.h` file created with similar contents:
```
#ifndef __TC_UTIL_USER_OVERRIDE_H__
#define __TC_UTIL_USER_OVERRIDE_H__

#include "semihost_extra.h"

// custom PRINT_DATA (replacing serial output with semihost writes)
#define PRINT_DATA(fmt, ...) semihost_log(fmt, ##__VA_ARGS__)
#define PRINT PRINT_DATA

#endif /* __TC_UTIL_USER_OVERRIDE_H__ */
```

Also make sure to add these configuration options to your test project:
```
CONFIG_ZTEST_VERBOSE_OUTPUT=y
CONFIG_ZTEST_ASSERT_VERBOSE=2
CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE=y
```
You can set CONFIG_ZTEST_ASSERT_VERBOSE to 1 to see failure data, 0 to only see failure line, 2 to see even successful lines of asserts.