### PR TITLE
Fixed enable bit blocking ADC channel setup

### DIFF
--- a/soc/arm/atmel_sam0/samc21/soc.h
+++ b/soc/arm/atmel_sam0/samc21/soc.h
@@ -52,6 +52,8 @@
 
 #endif /* _ASMLANGUAGE */
 
+#define ADC_SAM0_REFERENCE_ENABLE_PROTECTED
+
 #include "adc_fixup_sam0.h"
 #include "../common/soc_port.h"
 #include "../common/atmel_sam0_dt.h"


### PR DESCRIPTION
This issue inhibited proper ADC channel setup.

Eventually it will be resolved in zephyrproject-rtos/zephyr after merging the following PR: https://github.com/zephyrproject-rtos/zephyr/pull/60197

(If we update our own custom branch to the latest Zephyr version, this commit can be removed.)