### PR TITLE
MCAN: Saving into buffers should happen regardless of the bus off state

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -891,10 +891,6 @@ int can_mcan_send(const struct device *dev, const struct can_frame *frame, k_tim
 		return err;
 	}
 
-	if ((reg & CAN_MCAN_PSR_BO) != 0U) {
-		return -ENETUNREACH;
-	}
-
 	err = k_sem_take(&data->tx_sem, timeout);
 	if (err != 0) {
 		return -EAGAIN;


### PR DESCRIPTION
By buffers I mean the Message RAM. For a reference to the register in the datasheet search "Bus_Off Status" in https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-C20-C21-Family-Data-Sheet-DS60001479J.pdf