### PR TITLE
Update Zephyr sdk version to 0.16

### DIFF
--- a/cmake/modules/FindHostTools.cmake
+++ b/cmake/modules/FindHostTools.cmake
@@ -50,7 +50,7 @@ endif()
 
 find_package(Deprecated COMPONENTS XCC_USE_CLANG CROSS_COMPILE)
 
-find_package(Zephyr-sdk 0.15)
+find_package(Zephyr-sdk 0.16)
 
 # gperf is an optional dependency
 find_program(GPERF gperf)


### PR DESCRIPTION
This will be a more up to date version and the README in fluxgrip_software will also point to installing v0.16