### PR TITLE
Revert "Allocate 16 Kbyte for bootloader (#29)"

### DIFF
--- a/dts/arm/atmel/samc21x18.dtsi
+++ b/dts/arm/atmel/samc21x18.dtsi
@@ -14,8 +14,8 @@
 
 	soc {
 		nvmctrl: nvmctrl@41004000  {
-			flash0: flash@4000 {
-				reg = <0x4000 DT_SIZE_K(240)>;
+			flash0: flash@0 {
+				reg = <0 DT_SIZE_K(256)>;
 			};
 		};
 	};


### PR DESCRIPTION
This reverts commit ec01cab87040c1f20932710d0c6173ca783be167.